### PR TITLE
support for aarch64 jre for M1 and M2 based Mac machines.

### DIFF
--- a/vars/darwin.yml
+++ b/vars/darwin.yml
@@ -4,7 +4,7 @@ __installation_root_folder: "/Applications/Experitest"
 
 temp_folder: "/tmp/experitest"
 
-java_download_filename: "OpenJDK8U-jre_x64_mac_hotspot_{{ java_version }}.tar.gz"
+java_download_filename: "OpenJDK8U-jre_{{ ansible_architecture }}_mac_hotspot_{{ java_version }}.tar.gz"
 
 java_relative_path: "java/osx"
 


### PR DESCRIPTION
support for aarch64 jre for M1 and M2 based Mac machines.