### PR TITLE
Java upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Experitest - Java8 ansible role
+Experitest - Java ansible role
 =========
 
-This role will install \ uninstall Java8 (or alternatives) in all platforms
+This role will install \ uninstall Java (or alternatives) in all platforms
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Role Variables
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | state | should the application be present or absent | present, absent | present | no |
-| java_version | java jre version to install | string | 8u292-b10 | no |
+| java_version | java jre version to install | string | 17.0.18_8 | no |
 | installation_root_folder | the root folder in which the java application will be installed under jre folder | string | for mac: /Applications/Experitest <br> for windows: C:\\Experitest <br> for linux: /opt/Experitest | no |
 | update_java_path | add java bin path to system path variable | boolean | False | no |
 | custom_download_url | custom url to download the installation from (zip format) | string |  | no |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,14 +2,12 @@
 
 required_modifiable_fields:
   - installation_root_folder
-  - java_major_version
   - java_version
   - custom_download_username
   - custom_download_password
 
-__java_major_version: 17
-
-__java_version: "{{ java_major_version }}.0.18_8"
+__java_version: "17.0.18_8"
+java_major_version: "{{ java_version.split('.')[0] }}"
 
 cdn_name: "devops-artifacts.experitest.com"
 java_download_url: "https://{{ cdn_name }}/{{ java_relative_path }}/{{ java_download_filename }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,14 @@
 
 required_modifiable_fields:
   - installation_root_folder
+  - java_major_version
   - java_version
   - custom_download_username
   - custom_download_password
 
-__java_version: 17.0.3_7
+__java_major_version: 17
+
+__java_version: "{{ java_major_version }}.0.18_8"
 
 cdn_name: "devops-artifacts.experitest.com"
 java_download_url: "https://{{ cdn_name }}/{{ java_relative_path }}/{{ java_download_filename }}"

--- a/tasks/darwin-install.yml
+++ b/tasks/darwin-install.yml
@@ -135,7 +135,6 @@
       become: yes
       when:
         - extracted_java_dirs.matched | int > 0
-        - extracted_java_dirs.files[0].path != java_home
 
   when: not java_exists.stat.exists or java_needs_replacement | default(false)
 

--- a/tasks/darwin-install.yml
+++ b/tasks/darwin-install.yml
@@ -115,15 +115,27 @@
       become: yes
       when: unzip_java.rc != 0
 
+    - name: find extracted java folder
+      find:
+        paths: "{{ java_installation_folder }}"
+        file_type: directory
+        patterns: "jdk*"
+        recurse: no
+      register: extracted_java_dirs
+      become: yes
+
     - name: rename extracted java folder to consistent name
-      shell: |
-        extracted=$(find {{ java_installation_folder }} -maxdepth 1 -type d -name "jdk*" | head -1)
-        if [ -n "$extracted" ] && [ "$extracted" != "{{ java_home }}" ]; then
-          mv "$extracted" "{{ java_home }}"
-        fi
+      command:
+        argv:
+          - mv
+          - "{{ extracted_java_dirs.files[0].path }}"
+          - "{{ java_home }}"
       args:
         creates: "{{ java_home }}"
       become: yes
+      when:
+        - extracted_java_dirs.matched | int > 0
+        - extracted_java_dirs.files[0].path != java_home
 
   when: not java_exists.stat.exists or java_needs_replacement | default(false)
 

--- a/tasks/darwin-install.yml
+++ b/tasks/darwin-install.yml
@@ -115,6 +115,16 @@
       become: yes
       when: unzip_java.rc != 0
 
+    - name: rename extracted java folder to consistent name
+      shell: |
+        extracted=$(find {{ java_installation_folder }} -maxdepth 1 -type d -name "jdk*" | head -1)
+        if [ -n "$extracted" ] && [ "$extracted" != "{{ java_home }}" ]; then
+          mv "$extracted" "{{ java_home }}"
+        fi
+      args:
+        creates: "{{ java_home }}"
+      become: yes
+
   when: not java_exists.stat.exists or java_needs_replacement | default(false)
 
 

--- a/tasks/darwin-install.yml
+++ b/tasks/darwin-install.yml
@@ -115,26 +115,30 @@
       become: yes
       when: unzip_java.rc != 0
 
-    - name: find extracted java folder
-      find:
-        paths: "{{ java_installation_folder }}"
-        file_type: directory
-        patterns: "jdk*"
-        recurse: no
-      register: extracted_java_dirs
+    - name: set extracted java folder path
+      set_fact:
+        extracted_java_path: "{{ java_installation_folder }}/jdk-{{ java_version | replace('_', '+') }}-jre"
+
+    - name: check extracted java folder exists
+      stat:
+        path: "{{ extracted_java_path }}"
+      register: extracted_java_dir
       become: yes
+
+    - name: fail if extracted java folder not found
+      fail:
+        msg: "Expected extracted folder '{{ extracted_java_path }}' not found"
+      when: not extracted_java_dir.stat.exists
 
     - name: rename extracted java folder to consistent name
       command:
         argv:
           - mv
-          - "{{ extracted_java_dirs.files[0].path }}"
+          - "{{ extracted_java_path }}"
           - "{{ java_home }}"
       args:
         creates: "{{ java_home }}"
       become: yes
-      when:
-        - extracted_java_dirs.matched | int > 0
 
   when: not java_exists.stat.exists or java_needs_replacement | default(false)
 

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -76,25 +76,30 @@
       become: yes
       when: unzip_java.rc != 0
 
-    - name: find extracted java folder
-      find:
-        paths: "{{ java_installation_folder }}"
-        file_type: directory
-        patterns: "jdk*"
-        recurse: no
-      register: extracted_java_dirs
+    - name: set extracted java folder path
+      set_fact:
+        extracted_java_path: "{{ java_installation_folder }}/jdk-{{ java_version | replace('_', '+') }}-jre"
+
+    - name: check extracted java folder exists
+      stat:
+        path: "{{ extracted_java_path }}"
+      register: extracted_java_dir
       become: yes
+
+    - name: fail if extracted java folder not found
+      fail:
+        msg: "Expected extracted folder '{{ extracted_java_path }}' not found"
+      when: not extracted_java_dir.stat.exists
 
     - name: rename extracted java folder to consistent name
       command:
         argv:
           - mv
-          - "{{ extracted_java_dirs.files[0].path }}"
+          - "{{ extracted_java_path }}"
           - "{{ java_home }}"
       args:
         creates: "{{ java_home }}"
       become: yes
-      when: extracted_java_dirs.matched | int > 0
 
   when: not java_exists.stat.exists
 

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -76,6 +76,15 @@
       become: yes
       when: unzip_java.rc != 0
 
+    - name: rename extracted java folder to consistent name
+      shell: |
+        extracted=$(find {{ java_installation_folder }} -maxdepth 1 -type d -name "jdk*" | head -1)
+        if [ -n "$extracted" ] && [ "$extracted" != "{{ java_home }}" ]; then
+          mv "$extracted" "{{ java_home }}"
+        fi
+      args:
+        creates: "{{ java_home }}"
+      become: yes
 
   when: not java_exists.stat.exists
 

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -76,15 +76,27 @@
       become: yes
       when: unzip_java.rc != 0
 
+    - name: find extracted java folder
+      find:
+        paths: "{{ java_installation_folder }}"
+        file_type: directory
+        patterns: "jdk*"
+        recurse: no
+      register: extracted_java_dirs
+      become: yes
+
     - name: rename extracted java folder to consistent name
-      shell: |
-        extracted=$(find {{ java_installation_folder }} -maxdepth 1 -type d -name "jdk*" | head -1)
-        if [ -n "$extracted" ] && [ "$extracted" != "{{ java_home }}" ]; then
-          mv "$extracted" "{{ java_home }}"
-        fi
+      command:
+        argv:
+          - mv
+          - "{{ extracted_java_dirs.files[0].path }}"
+          - "{{ java_home }}"
       args:
         creates: "{{ java_home }}"
       become: yes
+      when:
+        - extracted_java_dirs.matched | int > 0
+        - extracted_java_dirs.files[0].path != java_home
 
   when: not java_exists.stat.exists
 

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -94,9 +94,7 @@
       args:
         creates: "{{ java_home }}"
       become: yes
-      when:
-        - extracted_java_dirs.matched | int > 0
-        - extracted_java_dirs.files[0].path != java_home
+      when: extracted_java_dirs.matched | int > 0
 
   when: not java_exists.stat.exists
 

--- a/tasks/windows-install.yml
+++ b/tasks/windows-install.yml
@@ -82,24 +82,28 @@
       become: yes
       when: unzip_java.failed
 
-    - name: find extracted java folder
-      win_find:
-        paths: "{{ java_installation_folder }}"
-        file_type: directory
-        patterns: "jdk*"
-        recurse: no
-      register: extracted_java_dirs
+    - name: set extracted java folder path
+      set_fact:
+        extracted_java_path: "{{ java_installation_folder }}\\jdk-{{ java_version | replace('_', '+') }}-jre"
+
+    - name: check extracted java folder exists
+      win_stat:
+        path: "{{ extracted_java_path }}"
+      register: extracted_java_dir
       become: yes
+
+    - name: fail if extracted java folder not found
+      fail:
+        msg: "Expected extracted folder '{{ extracted_java_path }}' not found"
+      when: not extracted_java_dir.stat.exists
 
     - name: rename extracted java folder to consistent name
       win_shell: |
-        $sourcePath = "{{ extracted_java_dirs.files[0].path }}"
         $targetName = Split-Path -Leaf "{{ java_home }}"
-        Rename-Item -Path $sourcePath -NewName $targetName
+        Rename-Item -Path "{{ extracted_java_path }}" -NewName $targetName
       args:
         creates: "{{ java_home }}"
       become: yes
-      when: extracted_java_dirs.matched | int > 0
 
   when: not java_exists.stat.exists
 

--- a/tasks/windows-install.yml
+++ b/tasks/windows-install.yml
@@ -82,6 +82,16 @@
       become: yes
       when: unzip_java.failed
 
+    - name: rename extracted java folder to consistent name
+      win_shell: |
+        $extracted = Get-ChildItem "{{ java_installation_folder }}" -Directory | Where-Object { $_.Name -like "jdk*" } | Select-Object -First 1
+        $dst = "{{ java_home }}"
+        if ($extracted -and !(Test-Path $dst)) {
+          Rename-Item -Path $extracted.FullName -NewName (Split-Path $dst -Leaf)
+        }
+      creates: "{{ java_home }}"
+      become: yes
+
   when: not java_exists.stat.exists
 
 

--- a/tasks/windows-install.yml
+++ b/tasks/windows-install.yml
@@ -82,15 +82,24 @@
       become: yes
       when: unzip_java.failed
 
-    - name: rename extracted java folder to consistent name
-      win_shell: |
-        $extracted = Get-ChildItem "{{ java_installation_folder }}" -Directory | Where-Object { $_.Name -like "jdk*" } | Select-Object -First 1
-        $dst = "{{ java_home }}"
-        if ($extracted -and !(Test-Path $dst)) {
-          Rename-Item -Path $extracted.FullName -NewName (Split-Path $dst -Leaf)
-        }
-      creates: "{{ java_home }}"
+    - name: find extracted java folder
+      win_find:
+        paths: "{{ java_installation_folder }}"
+        file_type: directory
+        patterns: "jdk*"
+        recurse: no
+      register: extracted_java_dirs
       become: yes
+
+    - name: rename extracted java folder to consistent name
+      win_command: >
+        Rename-Item -Path "{{ extracted_java_dirs.files[0].path }}" -NewName "{{ java_home | basename }}"
+      args:
+        creates: "{{ java_home }}"
+      become: yes
+      when:
+        - extracted_java_dirs.matched | int > 0
+        - extracted_java_dirs.files[0].path != java_home
 
   when: not java_exists.stat.exists
 

--- a/tasks/windows-install.yml
+++ b/tasks/windows-install.yml
@@ -99,9 +99,7 @@
       args:
         creates: "{{ java_home }}"
       become: yes
-      when:
-        - extracted_java_dirs.matched | int > 0
-        - extracted_java_dirs.files[0].path != java_home
+      when: extracted_java_dirs.matched | int > 0
 
   when: not java_exists.stat.exists
 

--- a/tasks/windows-install.yml
+++ b/tasks/windows-install.yml
@@ -92,8 +92,10 @@
       become: yes
 
     - name: rename extracted java folder to consistent name
-      win_command: >
-        Rename-Item -Path "{{ extracted_java_dirs.files[0].path }}" -NewName "{{ java_home | basename }}"
+      win_shell: |
+        $sourcePath = "{{ extracted_java_dirs.files[0].path }}"
+        $targetName = Split-Path -Leaf "{{ java_home }}"
+        Rename-Item -Path $sourcePath -NewName $targetName
       args:
         creates: "{{ java_home }}"
       become: yes

--- a/vars/darwin.yml
+++ b/vars/darwin.yml
@@ -4,7 +4,8 @@ __installation_root_folder: "/Applications/Experitest"
 
 temp_folder: "/tmp/experitest"
 
-java_download_filename: "OpenJDK8U-jre_{{ ansible_architecture }}_mac_hotspot_{{ java_version }}.tar.gz"
+java_arch: "{{ 'aarch64' if ansible_architecture == 'arm64' else ansible_architecture }}"
+java_download_filename: "OpenJDK{{ java_major_version }}U-jre_{{ java_arch }}_mac_hotspot_{{ java_version }}.tar.gz"
 
 java_relative_path: "java/osx"
 

--- a/vars/darwin.yml
+++ b/vars/darwin.yml
@@ -4,7 +4,7 @@ __installation_root_folder: "/Applications/Experitest"
 
 temp_folder: "/tmp/experitest"
 
-java_arch: "{{ 'aarch64' if ansible_architecture == 'arm64' else ansible_architecture }}"
+java_arch: "{{ 'aarch64' if ansible_architecture == 'arm64' else ('x64' if ansible_architecture == 'x86_64' else ansible_architecture) }}"
 java_download_filename: "OpenJDK{{ java_major_version }}U-jre_{{ java_arch }}_mac_hotspot_{{ java_version }}.tar.gz"
 
 java_relative_path: "java/osx"

--- a/vars/linux.yml
+++ b/vars/linux.yml
@@ -7,7 +7,7 @@ __installation_root_folder: "/opt/Experitest"
 # /var/tmp  - temp folder that is preservered after reboot
 temp_folder: /var/tmp/Experitest
 
-java_download_filename: "OpenJDK8U-jre_x64_linux_hotspot_{{ java_version }}.tar.gz"
+java_download_filename: "OpenJDK{{ java_major_version }}U-jre_x64_linux_hotspot_{{ java_version }}.tar.gz"
 
 java_relative_path: "java/linux"
 

--- a/vars/windows.yml
+++ b/vars/windows.yml
@@ -4,7 +4,7 @@ __installation_root_folder: "C:\\Experitest"
 
 temp_folder: "c:\\temp\\experitest"
 
-java_download_filename: "OpenJDK8U-jre_x64_windows_hotspot_{{ java_version }}.zip"
+java_download_filename: "OpenJDK{{ java_major_version }}U-jre_x64_windows_hotspot_{{ java_version }}.zip"
 
 java_relative_path: "java/windows"
 


### PR DESCRIPTION
This pull request updates the Ansible role for Java installation to support newer Java versions and improves cross-platform consistency in how Java is installed and referenced. The main changes include parameterizing the Java version and download filename, updating the default Java version, and ensuring the extracted Java directory is consistently named across macOS, Linux, and Windows.

**Java Version and Download Improvements:**

* The default Java version is updated to `17.0.18_8`, and the download filename is now dynamically constructed based on the Java major version and architecture, supporting future upgrades more easily. (`defaults/main.yml` [[1]](diffhunk://#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4L9-R10) `vars/darwin.yml` [[2]](diffhunk://#diff-0d11c85b8d34bd200e1078d3ca5fbf67b22692fd50d9b39b0fa0497ee6a1154bL7-R8) `vars/linux.yml` [[3]](diffhunk://#diff-f3416c800df14bca40e2d3c249264adf2419ac7dc5852a2fff61365822927160L10-R10) `vars/windows.yml` [[4]](diffhunk://#diff-07d167f4fad78c9184ff66b4e287f0b93c424075a1873c007ed9f2902c0240feL7-R7)

**Cross-Platform Installation Consistency:**

* After extraction, the Java installation folder is renamed to a consistent path (`java_home`) on all platforms (macOS, Linux, Windows), preventing issues with variable extracted directory names. (`tasks/darwin-install.yml` [[1]](diffhunk://#diff-8a71933bfe132f04c1adc149ae6c8dc62e05a23c5dc479d60c4dbfb0eb460611R118-R127) `tasks/linux-install.yml` [[2]](diffhunk://#diff-c17761d0a54fbf017473377026bca0865e03e7160e7a1fd81645f3942306f507R79-R87) `tasks/windows-install.yml` [[3]](diffhunk://#diff-2b316d932eac6544c1df39886f4cd7d53967e84b703833673ab828158cece9deR85-R94)

**Documentation Update:**

* The `README.md` is updated to reflect support for Java in general, not just Java 8.